### PR TITLE
feat: add vehicle reminders display component

### DIFF
--- a/app/(private)/(vehicles)/_components/VehicleDetailsPage/Reminder.tsx
+++ b/app/(private)/(vehicles)/_components/VehicleDetailsPage/Reminder.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+
+import { BellRingIcon, CalendarIcon, CarFront } from "lucide-react";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/app/ui/shadcn/Popover";
+import { Button } from "@/app/ui/shadcn/Button";
+import { ScheduleRecordType } from "@/app/lib/types/vehicle";
+import { cn } from "@/app/lib/utils/utils";
+import { StatusBadge, StatusType } from "@/app/ui/components/StatusBadge";
+import { useFormatter, useTranslations } from "next-intl";
+import { formatDate } from "@/app/lib/utils/dateUtils";
+
+function Reminder({ data }: { data: ScheduleRecordType[] }) {
+  const format = useFormatter();
+
+  const tc = useTranslations("VehicleExpenseCategory");
+  const ts = useTranslations("Status");
+  const tv = useTranslations("Vehicles");
+
+  const overdue = data.filter((r) => r.status === "overdue");
+  const due = data.filter((r) => r.status === "due");
+
+  return (
+    <div className="absolute -right-1 -top-1 z-10 flex items-center gap-2">
+      <Popover modal={true}>
+        <PopoverTrigger asChild>
+          <Button size="icon" className="relative h-12 w-12 [&_svg]:!size-5">
+            {data.length > 0 && (
+              <span className="absolute -right-1 -top-1 flex h-5 min-w-[20px] animate-bounce items-center justify-center rounded-full bg-destructive px-1 text-xs font-semibold text-white">
+                {data.length > 99 ? "99+" : data.length}
+              </span>
+            )}
+            <BellRingIcon className="h-6 w-6" />
+          </Button>
+        </PopoverTrigger>
+
+        <PopoverContent
+          align="end"
+          side="bottom"
+          className="max-h-[500px] w-[360px] overflow-hidden p-0"
+        >
+          <div className="border-b px-4 py-3">
+            <div className="text-sm font-semibold text-text-secondary">
+              {tv("plannedExpenses")}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {overdue.length > 0 && (
+                <span className="font-medium text-destructive">
+                  {overdue.length} {ts("overdue")}
+                </span>
+              )}
+              {overdue.length > 0 && due.length > 0 && " • "}
+              {due.length > 0 && (
+                <span>
+                  {due.length} {ts("due")}
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div className="max-h-[420px] overflow-y-auto">
+            {data.map((item) => (
+              <div
+                key={item._id}
+                className={cn(
+                  "group px-4 py-3 transition-colors",
+                  item.status === "overdue" && "bg-destructive/5"
+                )}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <div className="font-medium leading-tight text-text-primary">
+                    {item.title}
+                  </div>
+                  <StatusBadge status={item.status as StatusType} />
+                </div>
+                {item.category && (
+                  <p className="my-2 text-xs text-muted-foreground">
+                    {tc(item.category)}
+                  </p>
+                )}
+
+                <div className="mt-1 flex items-center justify-between gap-2 space-y-0.5 text-sm text-muted-foreground">
+                  {item.triggerOdometer && (
+                    <div className="flex items-center gap-2">
+                      <CarFront className="h-4 w-4" />
+                      <span>{format.number(item.triggerOdometer)} km</span>
+                    </div>
+                  )}
+
+                  {item.triggerDate && (
+                    <div className="flex items-center gap-2">
+                      <CalendarIcon className="h-4 w-4" />
+                      <span>{formatDate(item.triggerDate, "full")}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+export default Reminder;

--- a/app/(private)/(vehicles)/_components/VehicleDetailsPage/Reminder.tsx
+++ b/app/(private)/(vehicles)/_components/VehicleDetailsPage/Reminder.tsx
@@ -1,18 +1,20 @@
 import React from "react";
-
+import { useFormatter, useTranslations } from "next-intl";
 import { BellRingIcon, CalendarIcon, CarFront } from "lucide-react";
 
+import { formatDate } from "@/app/lib/utils/dateUtils";
+import { cn } from "@/app/lib/utils/utils";
+
+import { Button } from "@/app/ui/shadcn/Button";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/app/ui/shadcn/Popover";
-import { Button } from "@/app/ui/shadcn/Button";
-import { ScheduleRecordType } from "@/app/lib/types/vehicle";
-import { cn } from "@/app/lib/utils/utils";
+
 import { StatusBadge, StatusType } from "@/app/ui/components/StatusBadge";
-import { useFormatter, useTranslations } from "next-intl";
-import { formatDate } from "@/app/lib/utils/dateUtils";
+
+import { ScheduleRecordType } from "@/app/lib/types/vehicle";
 
 function Reminder({ data }: { data: ScheduleRecordType[] }) {
   const format = useFormatter();

--- a/app/(private)/(vehicles)/_components/VehicleDetailsPage/VehicleHeader.tsx
+++ b/app/(private)/(vehicles)/_components/VehicleDetailsPage/VehicleHeader.tsx
@@ -7,13 +7,10 @@ import { Avatar, AvatarImage } from "@/app/ui/shadcn/Avatar";
 import { Card, CardContent, CardHeader } from "@/app/ui/shadcn/Card";
 
 import VehicleStatsPanel from "@/app/(private)/(vehicles)/_components/VehicleDetailsPage/VehicleStatsPanel";
-import { useVehicleRemindersList } from "@/app/(private)/(vehicles)/_hooks/useVehicleRemindersList";
 import { Vehicle } from "@/app/lib/types/vehicle";
 
 function VehicleHeader({ vehicleData }: { vehicleData: Vehicle }) {
   const t = useTranslations("Table");
-
-  const { data, isLoading } = useVehicleRemindersList();
 
   return (
     <Card className={"flex w-fit flex-col lg:flex-row"}>

--- a/app/(private)/(vehicles)/_components/VehicleDetailsPage/index.tsx
+++ b/app/(private)/(vehicles)/_components/VehicleDetailsPage/index.tsx
@@ -7,9 +7,11 @@ import QueryKeys from "@/app/lib/utils/queryKeys";
 
 import AppLoader from "@/app/ui/components/common/AppLoader";
 
+import Reminder from "@/app/(private)/(vehicles)/_components/VehicleDetailsPage/Reminder";
 import VehicleDetails from "@/app/(private)/(vehicles)/_components/VehicleDetailsPage/VehicleDetails";
 import VehicleHeader from "@/app/(private)/(vehicles)/_components/VehicleDetailsPage/VehicleHeader";
 import { useCurrentVehicle } from "@/app/(private)/(vehicles)/_hooks/useCurrentVehicle";
+import { useVehicleRemindersList } from "@/app/(private)/(vehicles)/_hooks/useVehicleRemindersList";
 
 function VehicleDetailsPage() {
   const params = useParams();
@@ -23,6 +25,8 @@ function VehicleDetailsPage() {
     [QueryKeys.currentVehicle(vehicleId || "")],
     true
   );
+
+  const { data: reminders } = useVehicleRemindersList();
 
   return (
     <div className={"relative flex flex-1 flex-col gap-4"}>
@@ -42,6 +46,8 @@ function VehicleDetailsPage() {
           <VehicleDetails vehicleData={data.data} />
         </>
       )}
+
+      {reminders && reminders.length > 0 && <Reminder data={reminders} />}
     </div>
   );
 }

--- a/app/(private)/(vehicles)/_hooks/useVehicleRemindersList.tsx
+++ b/app/(private)/(vehicles)/_hooks/useVehicleRemindersList.tsx
@@ -21,7 +21,7 @@ export function useVehicleRemindersList() {
         queryKey: QueryKeys.vehicleScheduleRecords(vehicleId as string),
       });
 
-      return response;
+      return response.data;
     },
     queryKey: QueryKeys.vehicleReminders(vehicleId as string),
   });

--- a/app/lib/api/vehicle/getVehicleReminds.ts
+++ b/app/lib/api/vehicle/getVehicleReminds.ts
@@ -1,6 +1,13 @@
 import Notify from "@/app/lib/utils/notify";
 
-export async function getVehicleReminds({ vehicleId }: { vehicleId: string }) {
+import { ApiResponse } from "@/app/lib/types";
+import { ScheduleRecordType } from "@/app/lib/types/vehicle";
+
+export async function getVehicleReminds({
+  vehicleId,
+}: {
+  vehicleId: string;
+}): Promise<ApiResponse<ScheduleRecordType[]>> {
   const url = `/api/vehicles/${vehicleId}/reminders`;
 
   const response = await fetch(`${url}`, {

--- a/app/lib/intl/en.json
+++ b/app/lib/intl/en.json
@@ -75,7 +75,8 @@
     "expensesByCategory": "Expenses by Category",
     "totalFuelCost": "Fuel Cost",
     "totalExpensesCost": "Maintenance costs",
-    "oneKilometerCost": "Cost per kilometer"
+    "oneKilometerCost": "Cost per kilometer",
+    "plannedExpenses": "Planned Expenses"
   },
   "Sidebar": {
     "home": "Home",

--- a/app/lib/intl/uk.json
+++ b/app/lib/intl/uk.json
@@ -75,7 +75,8 @@
     "expensesByCategory": "Витрати за категоріями",
     "totalFuelCost": "Вартість палива",
     "totalExpensesCost": "Витрати на обслуговування",
-    "oneKilometerCost": "Вартість за кілометр"
+    "oneKilometerCost": "Вартість за кілометр",
+    "plannedExpenses": "Заплановані витрати"
   },
   "Sidebar": {
     "home": "Головна",

--- a/app/ui/components/common/DataTable/components/ScheduleRecordListItem.tsx
+++ b/app/ui/components/common/DataTable/components/ScheduleRecordListItem.tsx
@@ -24,11 +24,17 @@ export default function ScheduleRecordListItem({
   return (
     <CollapsibleItem
       title={
-        <div className="flex flex-row justify-between gap-1">
+        <div className="flex flex-row justify-between gap-0">
           <div className="flex w-fit flex-col gap-1">
-            <span className="inline-block origin-left scale-75 text-sm">
-              {formatDate(item.createdAt, "short")}
-            </span>
+            <div className={"flex items-center"}>
+              <span className="inline-block origin-left scale-75 text-sm">
+                {formatDate(item.createdAt, "short")}
+              </span>
+              <div className={"w-[100px]"}>
+                <StatusBadge status={item.status as StatusType} />
+              </div>
+            </div>
+
             <span className="inline-block origin-left scale-95 text-sm font-bold">
               {item.title}
             </span>
@@ -49,10 +55,10 @@ export default function ScheduleRecordListItem({
           <span className="font-semibold">{tTable("triggerDate")}:</span>
           <span>{formatDate(item.triggerDate, "short")}</span>
 
-          <span className="font-semibold">{tTable("status")}:</span>
-          <div className={"w-fit"}>
-            <StatusBadge status={item.status as StatusType} />
-          </div>
+          {/*<span className="font-semibold">{tTable("status")}:</span>*/}
+          {/*<div className={"w-fit"}>*/}
+          {/*  <StatusBadge status={item.status as StatusType} />*/}
+          {/*</div>*/}
 
           {item.record && (
             <>


### PR DESCRIPTION
- Create new Reminder component for displaying vehicle reminders in popover
- Add reminders integration to VehicleDetailsPage
- Update useVehicleRemindersList hook to return correct data structure
- Fix API response typing in getVehicleReminds
- Add internationalization for "plannedExpenses" label
- Improve ScheduleRecordListItem layout with status badge positioning
- Remove unused reminders hook from VehicleHeader